### PR TITLE
Update the runtime version from 49 to 50, and more

### DIFF
--- a/com.ranfdev.DistroShelf.json
+++ b/com.ranfdev.DistroShelf.json
@@ -1,7 +1,7 @@
 {
     "id": "com.ranfdev.DistroShelf",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable",
@@ -18,14 +18,7 @@
     ],
     "cleanup": [
         "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
+        "/lib/pkgconfig"
     ],
     "modules": [
         {


### PR DESCRIPTION
- Update the runtime version to 50
- Drop ineffective cleanup commands